### PR TITLE
✨ CowSwapper: v1.1.1, only accept beforeSwap before the swap

### DIFF
--- a/.github/workflows/foundryFuzz.yml
+++ b/.github/workflows/foundryFuzz.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run format
         run: forge fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Run format
         run: forge fmt --check

--- a/foundry.toml
+++ b/foundry.toml
@@ -30,6 +30,7 @@ unchecked_cheatcode_artifacts = true
 # - 5574: Contract code size exceeds 24576 bytes
 ignored_error_codes = [2394, 2424, 3860, 4591, 5574, 8429]
 ignored_warnings_from = [
+    "lib/accounts-v2/lib/slipstream/contracts/gauge/interfaces/ICLPool.sol",
     "lib/accounts-v2/lib/slipstream/contracts/libraries/EnumerableSet.sol",
     "lib/cowprotocol/",
     "lib/flash-loan-router/",
@@ -44,6 +45,7 @@ exclude_lints = [
 ignore = [
     "**/merkl/**/*",
     "**/merkl-operator/**/*",
+    "**/CompilePragma7Dot6.t.sol",
 ]
 
 [profile.lite]

--- a/src/cow-swapper/CowSwapper.sol
+++ b/src/cow-swapper/CowSwapper.sol
@@ -30,7 +30,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
     ////////////////////////////////////////////////////////////// */
 
     // The version of the CowSwapper.
-    string public constant VERSION = "1.1.0";
+    string public constant VERSION = "1.1.1";
 
     // The EIP-1271 magic value.
     bytes4 internal constant MAGIC_VALUE = 0x1626ba7e;
@@ -97,6 +97,9 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
     // The amount of tokenIn to swap (sellAmount).
     uint256 internal transient amountIn;
 
+    // The balance of tokenIn held just before the settlement, used to detect if the swap already happened.
+    uint256 internal transient balanceBefore;
+
     // The order hash.
     bytes32 internal transient orderHash;
     // The message hash.
@@ -119,6 +122,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
     error OnlyHooksTrampoline();
     error OnlyFlashLoanRouter();
     error Reentered();
+    error SwapAlreadyExecuted();
 
     /* //////////////////////////////////////////////////////////////
                                 EVENTS
@@ -352,7 +356,8 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
 
         // Cache the balance of tokenIn before the swap.
         address tokenIn_ = tokenIn;
-        uint256 balanceBefore = IERC20(tokenIn_).balanceOf(address(this));
+        uint256 balanceBefore_ = IERC20(tokenIn_).balanceOf(address(this));
+        balanceBefore = balanceBefore_;
 
         // Callback to flash loan router, this will settle the swap.
         FLASH_LOAN_ROUTER.borrowerCallBack(callBackData);
@@ -360,7 +365,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
         // Verify that "isValidSignature()" was called.
         // A malicious solver could modify the EIP-1271 signature, skipping the check that the orderHash is correct.
         // If isValidSignature() would be skipped, tokenIn would not be transferred from this contract to the vault relayer.
-        if (IERC20(tokenIn_).balanceOf(address(this)) != balanceBefore - amountIn) {
+        if (IERC20(tokenIn_).balanceOf(address(this)) != balanceBefore_ - amountIn) {
             revert MissingSignatureVerification();
         }
 
@@ -406,6 +411,11 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
     function beforeSwap(bytes calldata initiatorData) external {
         // Caller must be the Hooks Trampoline.
         if (msg.sender != HOOKS_TRAMPOLINE) revert OnlyHooksTrampoline();
+
+        // The swap parameters may only be set before the swap, so the sell token must still be fully present.
+        // Once it has been pulled the parameters are final and may not be changed. A re-supplied tokenIn balance
+        // is detected by the "balanceBefore_ - amountIn" check in executeAction().
+        if (IERC20(tokenIn).balanceOf(address(this)) != balanceBefore) revert SwapAlreadyExecuted();
 
         // Cache variables.
         address account_ = account;

--- a/test/fuzz/cow-swapper/CowSwapper/BeforeSwap.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/BeforeSwap.fuzz.t.sol
@@ -35,6 +35,22 @@ contract BeforeSwap_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         cowSwapper.beforeSwap(initiatorData);
     }
 
+    function testFuzz_Revert_beforeSwap_SwapAlreadyExecuted(uint256 balanceBefore, bytes calldata initiatorData)
+        public
+    {
+        // Given: balanceBefore differs from the current tokenIn balance,
+        // i.e. the sell token was already pulled, so beforeSwap is being called after the swap.
+        balanceBefore = bound(balanceBefore, 1, type(uint256).max);
+        cowSwapper.setTokenIn(address(token0));
+        cowSwapper.setBalanceBefore(balanceBefore);
+
+        // When: Hooks trampoline calls beforeSwap.
+        // Then: it should revert.
+        vm.prank(address(hooksTrampoline));
+        vm.expectRevert(CowSwapper.SwapAlreadyExecuted.selector);
+        cowSwapper.beforeSwap(initiatorData);
+    }
+
     function testFuzz_Revert_executeAction_InvalidSwapFee(
         address initiator,
         uint64 maxSwapFee,

--- a/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
@@ -623,6 +623,70 @@ contract EndToEnd_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         flashLoanRouter.flashLoanAndSettle(loans, settlementCallData);
     }
 
+    function testFuzz_Revert_EndToEnd_TokenInReturnedAfterSwap(
+        uint256 initiatorPrivateKey,
+        uint64 swapFee,
+        GPv2Order.Data memory order
+    ) public {
+        // Given: Valid initiator, swap fee and order.
+        initiatorPrivateKey = givenValidPrivatekey(initiatorPrivateKey);
+        address initiator = vm.addr(initiatorPrivateKey);
+        swapFee = uint64(bound(swapFee, 0, MAX_FEE));
+        givenValidOrder(swapFee, order);
+
+        // And: Cow swapper is set as asset manager with initiator.
+        setCowSwapper(initiator);
+
+        // And: Account has sufficient tokenIn balance and tokenIn is approved.
+        depositErc20InAccount(account, ERC20Mock(address(order.sellToken)), order.sellAmount);
+        cowSwapper.approveToken(address(order.sellToken));
+
+        // And: Router can execute the swap.
+        deal(address(order.buyToken), address(routerMock), order.buyAmount, true);
+
+        // And: The settlement is funded so it can return amountIn of tokenIn to the cow swapper mid-flow.
+        deal(address(token0), address(settlement), order.sellAmount, true);
+
+        // And: Valid EIP-1271 signature.
+        bytes memory signature =
+            abi.encodePacked(address(cowSwapper), getSignature(address(account), swapFee, order, initiatorPrivateKey));
+
+        Loan.Data[] memory loans = new Loan.Data[](1);
+        loans[0] = Loan.Data({
+            amount: order.sellAmount,
+            borrower: IBorrower(address(cowSwapper)),
+            lender: address(account),
+            token: IERC20(address(order.sellToken))
+        });
+
+        // And: The post-swap phase returns amountIn of tokenIn to the cow swapper, then runs a late beforeSwap.
+        bytes memory settlementCallData;
+        {
+            (
+                address[] memory tokens,
+                uint256[] memory clearingPrices,
+                ICowSettlement.Trade[] memory trades,
+                ICowSettlement.Interaction[][3] memory interactions
+            ) = getSettlementData(swapFee, order, signature);
+
+            bytes memory lateHookData = abi.encodePacked(address(token0), uint112(1), order.validTo, uint64(0));
+            interactions[2] = new ICowSettlement.Interaction[](2);
+            interactions[2][0] = ICowSettlement.Interaction({
+                target: address(token0),
+                value: 0,
+                callData: abi.encodeCall(token0.transfer, (address(cowSwapper), order.sellAmount))
+            });
+            interactions[2][1] = getBeforeSwapHookInteraction(lateHookData);
+            settlementCallData = abi.encodeCall(ICowSettlement.settle, (tokens, clearingPrices, trades, interactions));
+        }
+
+        // When: The solver calls the flash loan router.
+        // Then: the returned tokenIn leaves a surplus that the executeAction balance check rejects.
+        vm.prank(solver);
+        vm.expectRevert(CowSwapper.MissingSignatureVerification.selector);
+        flashLoanRouter.flashLoanAndSettle(loans, settlementCallData);
+    }
+
     function testFuzz_Success_EndToEnd_Initiator(
         uint256 initiatorPrivateKey,
         uint64 swapFee,
@@ -760,5 +824,84 @@ contract EndToEnd_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
 
         // And: Positive slippage can be pocketed by solver.
         assertEq(order.buyToken.balanceOf(address(settlement)), buyAmount - buyClearingPrice);
+    }
+
+    function testFuzz_Success_EndToEnd_BeforeSwapAfterSwapHasNoEffect(
+        uint256 initiatorPrivateKey,
+        uint64 swapFee,
+        GPv2Order.Data memory order,
+        uint256 buyClearingPrice,
+        uint256 buyAmount
+    ) public {
+        // Given: Valid initiator, swap fee and order.
+        initiatorPrivateKey = givenValidPrivatekey(initiatorPrivateKey);
+        address initiator = vm.addr(initiatorPrivateKey);
+        swapFee = uint64(bound(swapFee, 0, MAX_FEE));
+        givenValidOrder(swapFee, order);
+
+        // And: Cow swapper is set as asset manager with initiator.
+        setCowSwapper(initiator);
+
+        // And: Account has sufficient tokenIn balance and tokenIn is approved.
+        depositErc20InAccount(account, ERC20Mock(address(order.sellToken)), order.sellAmount);
+        cowSwapper.approveToken(address(order.sellToken));
+
+        // And: Clearing price is better than order demand with positive slippage.
+        buyClearingPrice = bound(buyClearingPrice, order.buyAmount + 1, type(uint160).max);
+        buyAmount = bound(buyAmount, buyClearingPrice, type(uint160).max);
+        deal(address(order.buyToken), address(routerMock), buyAmount, true);
+
+        // And: Valid EIP-1271 signature.
+        bytes memory signature =
+            abi.encodePacked(address(cowSwapper), getSignature(address(account), swapFee, order, initiatorPrivateKey));
+
+        Loan.Data[] memory loans = new Loan.Data[](1);
+        loans[0] = Loan.Data({
+            amount: order.sellAmount,
+            borrower: IBorrower(address(cowSwapper)),
+            lender: address(account),
+            token: IERC20(address(order.sellToken))
+        });
+
+        // And: An extra beforeSwap() (setting tokenOut to token0) is included in both the intra (interactions[1])
+        // and post (interactions[2]) phases, both of which run after the sell token is pulled.
+        bytes memory settlementCallData;
+        {
+            (
+                address[] memory tokens,
+                uint256[] memory clearingPrices,
+                ICowSettlement.Trade[] memory trades,
+                ICowSettlement.Interaction[][3] memory interactions
+            ) = getSettlementData(swapFee, order, signature, buyClearingPrice, buyAmount);
+            bytes memory lateHookData = abi.encodePacked(address(token0), uint112(1), order.validTo, uint64(0));
+            ICowSettlement.Interaction memory lateHook = getBeforeSwapHookInteraction(lateHookData);
+
+            // Prepend the extra beforeSwap to the intra phase, keeping the existing swap interactions after it.
+            ICowSettlement.Interaction[] memory intraInteractions =
+                new ICowSettlement.Interaction[](interactions[1].length + 1);
+            intraInteractions[0] = lateHook;
+            for (uint256 i = 0; i < interactions[1].length; ++i) {
+                intraInteractions[i + 1] = interactions[1][i];
+            }
+            interactions[1] = intraInteractions;
+
+            interactions[2] = new ICowSettlement.Interaction[](1);
+            interactions[2][0] = lateHook;
+            settlementCallData = abi.encodeCall(ICowSettlement.settle, (tokens, clearingPrices, trades, interactions));
+        }
+
+        // When: The solver calls the flash loan router.
+        vm.prank(solver);
+        flashLoanRouter.flashLoanAndSettle(loans, settlementCallData);
+
+        // Then: the extra beforeSwap calls have no effect (the trampoline ignores their reverts), so the result
+        // is the normal one.
+        assertEq(cowSwapper.getAccount(), address(0));
+        uint256 fee = buyClearingPrice * swapFee / 1e18;
+        assertEq(order.buyToken.balanceOf(address(account)), buyClearingPrice - fee);
+        assertEq(order.buyToken.balanceOf(initiator), fee);
+        // And: the cow swapper holds no leftover tokens.
+        assertEq(order.buyToken.balanceOf(address(cowSwapper)), 0);
+        assertEq(token0.balanceOf(address(cowSwapper)), 0);
     }
 }

--- a/test/fuzz/cow-swapper/CowSwapper/_CowSwapper.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/_CowSwapper.fuzz.t.sol
@@ -228,19 +228,8 @@ abstract contract CowSwapper_Fuzz_Test is Fuzz_Test, BalancerV2Fixture, CowSwapF
         });
 
         // And: BeforeSwap is called in pre swap hook.
-        {
-            HooksTrampoline.Hook[] memory hooks = new HooksTrampoline.Hook[](1);
-            bytes memory initiatorData =
-                abi.encodePacked(order.buyToken, uint112(order.buyAmount), order.validTo, swapFee);
-            hooks[0] = HooksTrampoline.Hook({
-                target: address(cowSwapper),
-                callData: abi.encodeCall(cowSwapper.beforeSwap, (initiatorData)),
-                gasLimit: 80_000
-            });
-            interactions[0][1] = ICowSettlement.Interaction({
-                target: address(hooksTrampoline), value: 0, callData: abi.encodeCall(hooksTrampoline.execute, (hooks))
-            });
-        }
+        bytes memory initiatorData = abi.encodePacked(order.buyToken, uint112(order.buyAmount), order.validTo, swapFee);
+        interactions[0][1] = getBeforeSwapHookInteraction(initiatorData);
 
         // Swap interactions.
         interactions[1] = new ICowSettlement.Interaction[](2);
@@ -258,6 +247,22 @@ abstract contract CowSwapper_Fuzz_Test is Fuzz_Test, BalancerV2Fixture, CowSwapF
         });
 
         // No Post Swap interactions.
+    }
+
+    function getBeforeSwapHookInteraction(bytes memory initiatorData)
+        internal
+        view
+        returns (ICowSettlement.Interaction memory interaction)
+    {
+        HooksTrampoline.Hook[] memory hooks = new HooksTrampoline.Hook[](1);
+        hooks[0] = HooksTrampoline.Hook({
+            target: address(cowSwapper),
+            callData: abi.encodeCall(cowSwapper.beforeSwap, (initiatorData)),
+            gasLimit: 80_000
+        });
+        interaction = ICowSettlement.Interaction({
+            target: address(hooksTrampoline), value: 0, callData: abi.encodeCall(hooksTrampoline.execute, (hooks))
+        });
     }
 
     function getLoansWithSettlement(Loan.Data[] calldata loans, bytes calldata settlementCallData)

--- a/test/utils/extensions/CowSwapperExtension.sol
+++ b/test/utils/extensions/CowSwapperExtension.sol
@@ -47,6 +47,14 @@ contract CowSwapperExtension is CowSwapper {
         return messageHash;
     }
 
+    function getBalanceBefore() external view returns (uint256) {
+        return balanceBefore;
+    }
+
+    function setBalanceBefore(uint256 balanceBefore_) external {
+        balanceBefore = balanceBefore_;
+    }
+
     function setAccount(address account_) external {
         account = account_;
     }


### PR DESCRIPTION
- beforeSwap reverts (SwapAlreadyExecuted) once the sell token has been pulled, so the swap parameters are final once the swap runs
- tests: cover beforeSwap in the intra/post phases and a re-supplied tokenIn balance
- extract getBeforeSwapHookInteraction harness helper