### PR TITLE
✅ exclude settlement contracts from fuzzed initiator

### DIFF
--- a/test/fuzz/cow-swapper/CowSwapper/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/ExecuteAction.fuzz.t.sol
@@ -952,7 +952,11 @@ contract ExecuteAction_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         givenValidOrder(swapFee, order);
 
         // And: Cow swapper is set as asset manager with initiator.
+        // Initiator must not be a contract holding buyToken during the settlement.
         vm.assume(initiator != address(0));
+        vm.assume(initiator != address(settlement));
+        vm.assume(initiator != address(cowSwapper));
+        vm.assume(initiator != address(account));
         setCowSwapper(initiator);
 
         // And: Cow Swapper has balance sellToken.


### PR DESCRIPTION
High fuzz on main failed in `testFuzz_Success_executeAction_AccountOwner`: the fuzzer drew `initiator == address(settlement)`, which legitimately holds slippage + fee after the settlement, breaking the fee balance assertion. Exclude settlement, cowSwapper and account from the fuzzed initiator.

Failing run: https://github.com/arcadia-finance/asset-managers/actions/runs/27406768833