### PR TITLE
🔧 support forge 1.8

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,14 @@ optimizer = true
 optimizer_runs = 200
 fuzz = { runs = 50, max_test_rejects = 100_000_000}
 no_match_path = "**/{script/}*"
+dynamic_test_linking = false
+isolate = false
+compilation_restrictions = [
+    { paths = "lib/accounts-v2/lib/slipstream/contracts/**", version = "=0.7.6" },
+    { paths = "lib/accounts-v2/lib/v3-core/contracts/**", version = "=0.7.6" },
+    { paths = "lib/accounts-v2/lib/v3-periphery/contracts/**", version = "=0.7.6" },
+    { paths = "lib/accounts-v2/lib/swap-router-contracts/contracts/**", version = "=0.7.6" },
+]
 remappings = [
     "lib/accounts-v2/lib/openzeppelin-contracts-upgradeable-v4.9:@openzeppelin/=lib/accounts-v2/lib/openzeppelin-contracts-v4.9/",
     "lib/accounts-v2/lib/merkl-contracts:@openzeppelin/contracts/=lib/accounts-v2/lib/openzeppelin-contracts-v4.9/contracts/",
@@ -16,6 +24,12 @@ remappings = [
     "lib/accounts-v2/lib/swap-router-contracts:@openzeppelin/=lib/accounts-v2/lib/openzeppelin-contracts-v3.4/",
     "lib/accounts-v2/lib/v4-periphery:@openzeppelin/=lib/accounts-v2/lib/v4-periphery/lib/v4-core/lib/openzeppelin-contracts/",
     "lib/accounts-v2/lib/v4-periphery/lib/v4-core:@openzeppelin/=lib/accounts-v2/lib/v4-periphery/lib/v4-core/lib/openzeppelin-contracts/",
+    "@uniswap/v2-core/contracts=lib/accounts-v2/test/utils/fixtures/swap-router-02",
+    "@uniswap/v3-core/contracts/=lib/accounts-v2/lib/v3-core/contracts/",
+    "@uniswap/v3-periphery/contracts/=lib/accounts-v2/lib/v3-periphery/contracts/",
+    "@uniswap/v4-core/=lib/accounts-v2/lib/v4-periphery/lib/v4-core/",
+    "contracts/=lib/accounts-v2/lib/slipstream/contracts",
+    "solmate/=lib/accounts-v2/lib/solmate/",
 ]
 fs_permissions = [{ access = "read", path = "./out"}, { access = "write", path = "./script/out"}]
 unchecked_cheatcode_artifacts = true

--- a/test/fuzz/cl-managers/base/Slipstream/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Claim.fuzz.t.sol
@@ -104,7 +104,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         claimFee = uint64(bound(claimFee, 0, 1e18));
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -129,7 +130,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), type(uint256).max, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
         uint256 rewards;
         if (
@@ -194,7 +196,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         claimFee = uint64(bound(claimFee, 0, 1e18));
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -238,7 +241,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), rewards, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling claim.
@@ -277,7 +281,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         claimFee = uint64(bound(claimFee, 0, 1e18));
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -302,7 +307,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), type(uint256).max, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
         uint256 rewards;
         if (
@@ -367,7 +373,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         claimFee = uint64(bound(claimFee, 0, 1e18));
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -411,7 +418,8 @@ contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), rewards, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling claim.

--- a/test/fuzz/cl-managers/base/Slipstream/Unstake.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Unstake.fuzz.t.sol
@@ -83,7 +83,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         setPositionState(position);
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -108,7 +109,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), type(uint256).max, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling unstake.
@@ -159,7 +161,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         setPositionState(position);
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -202,7 +205,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), rewards, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling unstake.
@@ -233,7 +237,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         setPositionState(position);
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -258,7 +263,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), type(uint256).max, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling unstake.
@@ -309,7 +315,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         setPositionState(position);
 
         // And : An initial rewardGrowthGlobalX128.
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Last);
 
         // Create staked position.
@@ -352,7 +359,8 @@ contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         vm.warp(block.timestamp + 1);
         deal(AERO, address(gauge), rewards, true);
         stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-        stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+        stdstore.target(address(poolCl))
+            .sig(poolCl.rewardGrowthGlobalX128.selector)
             .checked_write(rewardGrowthGlobalX128Current);
 
         // When: Calling unstake.

--- a/test/fuzz/cl-managers/compounders/Compounder/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/Compound.fuzz.t.sol
@@ -76,7 +76,7 @@ contract Compound_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/compounders/Compounder/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/SetAccountInfo.fuzz.t.sol
@@ -98,9 +98,13 @@ contract SetAccountInfo_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setInitiator on the compounder.

--- a/test/fuzz/cl-managers/compounders/CompounderSlipstream/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderSlipstream/Compound.fuzz.t.sol
@@ -88,7 +88,7 @@ contract Rebalance_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz_T
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }
@@ -334,7 +334,8 @@ contract Rebalance_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz_T
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -474,7 +475,8 @@ contract Rebalance_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz_T
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 

--- a/test/fuzz/cl-managers/compounders/CompounderSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderSlipstream/ExecuteAction.fuzz.t.sol
@@ -581,7 +581,8 @@ contract ExecuteAction_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -721,7 +722,8 @@ contract ExecuteAction_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), rewards, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -863,7 +865,8 @@ contract ExecuteAction_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -1001,7 +1004,8 @@ contract ExecuteAction_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), rewards, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Compound.fuzz.t.sol
@@ -80,7 +80,7 @@ contract Compound_CompounderUniswapV3_Fuzz_Test is CompounderUniswapV3_Fuzz_Test
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Compound.fuzz.t.sol
@@ -82,7 +82,7 @@ contract Rebalance_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_Tes
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/Rebalance.fuzz.t.sol
@@ -85,7 +85,7 @@ contract Rebalance_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/SetAccountInfo.fuzz.t.sol
@@ -116,9 +116,13 @@ contract SetAccountInfo_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setInitiator on the compounder.

--- a/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/ExecuteAction.fuzz.t.sol
@@ -901,7 +901,8 @@ contract ExecuteAction_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -1049,7 +1050,8 @@ contract ExecuteAction_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), rewards, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -1187,7 +1189,8 @@ contract ExecuteAction_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -1335,7 +1338,8 @@ contract ExecuteAction_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fu
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), rewards, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 

--- a/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Rebalance.fuzz.t.sol
@@ -95,7 +95,7 @@ contract Rebalance_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz_T
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }
@@ -341,7 +341,8 @@ contract Rebalance_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz_T
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 
@@ -475,7 +476,8 @@ contract Rebalance_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz_T
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
 

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Rebalance.fuzz.t.sol
@@ -87,7 +87,7 @@ contract Rebalance_RebalancerUniswapV3_Fuzz_Test is RebalancerUniswapV3_Fuzz_Tes
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Rebalance.fuzz.t.sol
@@ -89,7 +89,7 @@ contract Rebalance_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_Tes
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/Claim.fuzz.t.sol
@@ -76,7 +76,7 @@ contract Claim_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/SetAccountInfo.fuzz.t.sol
@@ -83,9 +83,13 @@ contract SetAccountInfo_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setInitiator on the compounder.

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Claim.fuzz.t.sol
@@ -87,7 +87,7 @@ contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuz
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }
@@ -399,7 +399,8 @@ contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuz
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = stakedSlipstreamAM.rewardOf(position.id);
@@ -503,7 +504,8 @@ contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuz
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = stakedSlipstreamAM.rewardOf(position.id);
@@ -605,7 +607,8 @@ contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuz
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = wrappedStakedSlipstream.rewardOf(position.id);
@@ -701,7 +704,8 @@ contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuz
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = wrappedStakedSlipstream.rewardOf(position.id);

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/ExecuteAction.fuzz.t.sol
@@ -270,7 +270,8 @@ contract ExecuteAction_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstrea
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = stakedSlipstreamAM.rewardOf(position.id);
@@ -368,7 +369,8 @@ contract ExecuteAction_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstrea
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = stakedSlipstreamAM.rewardOf(position.id);
@@ -452,7 +454,8 @@ contract ExecuteAction_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstrea
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = wrappedStakedSlipstream.rewardOf(position.id);
@@ -552,7 +555,8 @@ contract ExecuteAction_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstrea
             vm.warp(block.timestamp + 1);
             deal(AERO, address(gauge), type(uint256).max, true);
             stdstore.target(address(poolCl)).sig(poolCl.rewardReserve.selector).checked_write(type(uint256).max);
-            stdstore.target(address(poolCl)).sig(poolCl.rewardGrowthGlobalX128.selector)
+            stdstore.target(address(poolCl))
+                .sig(poolCl.rewardGrowthGlobalX128.selector)
                 .checked_write(rewardGrowthGlobalX128Current);
         }
         rewards = wrappedStakedSlipstream.rewardOf(position.id);

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Claim.fuzz.t.sol
@@ -78,7 +78,7 @@ contract Compound_YieldClaimerUniswapV3_Fuzz_Test is YieldClaimerUniswapV3_Fuzz_
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Claim.fuzz.t.sol
@@ -78,7 +78,7 @@ contract Compound_YieldClaimerUniswapV4_Fuzz_Test is YieldClaimerUniswapV4_Fuzz_
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
@@ -106,7 +106,7 @@ contract EndToEnd_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         // Then: it should revert.
         vm.prank(solver);
         if (!isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cow-swapper/CowSwapper/FlashLoanAndCallBack.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/FlashLoanAndCallBack.fuzz.t.sol
@@ -117,7 +117,7 @@ contract FlashLoanAndCallBack_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         // Then: it should revert
         vm.prank(address(flashLoanRouter));
         if (!isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/cow-swapper/CowSwapper/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/SetAccountInfo.fuzz.t.sol
@@ -96,9 +96,13 @@ contract SetAccountInfo_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setAccountInfo on the cowSwapper.

--- a/test/fuzz/merkl-operator/MerklOperator/Claim.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/Claim.fuzz.t.sol
@@ -62,7 +62,7 @@ contract Claim_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/merkl-operator/MerklOperator/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/SetAccountInfo.fuzz.t.sol
@@ -69,9 +69,13 @@ contract SetAccountInfo_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setInitiator on the compounder.

--- a/test/fuzz/merkl-operator/MerklOperatorBase/Claim.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperatorBase/Claim.fuzz.t.sol
@@ -62,7 +62,7 @@ contract Claim_MerklOperatorBase_Fuzz_Test is MerklOperatorBase_Fuzz_Test {
         // Then : it should revert
         vm.prank(caller);
         if (account_.code.length == 0 && !isPrecompile(account_)) {
-            vm.expectRevert(abi.encodePacked("call to non-contract address ", vm.toString(account_)));
+            vm.expectRevert(bytes(""));
         } else {
             vm.expectRevert(bytes(""));
         }

--- a/test/fuzz/merkl-operator/MerklOperatorBase/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperatorBase/SetAccountInfo.fuzz.t.sol
@@ -54,9 +54,13 @@ contract SetAccountInfo_MerklOperatorBase_Fuzz_Test is MerklOperatorBase_Fuzz_Te
         // Given: Account has an invalid version.
         accountVersion = bound(accountVersion, 0, 2);
         AccountVariableVersion account_ = new AccountVariableVersion(accountVersion, address(factory));
-        stdstore.target(address(factory)).sig(factory.isAccount.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.isAccount.selector)
+            .with_key(address(account_))
             .checked_write(true);
-        stdstore.target(address(factory)).sig(factory.accountIndex.selector).with_key(address(account_))
+        stdstore.target(address(factory))
+            .sig(factory.accountIndex.selector)
+            .with_key(address(account_))
             .checked_write(2);
 
         // When: Owner calls setInitiator on the compounder.


### PR DESCRIPTION
Adapt config and revert assertions to forge 1.8, and bump accounts-v2.