### PR TITLE
🚨 suppress intentional forge 1.8 lint findings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,6 @@ optimizer = true
 optimizer_runs = 200
 fuzz = { runs = 50, max_test_rejects = 100_000_000}
 no_match_path = "**/{script/}*"
-dynamic_test_linking = false
 isolate = false
 compilation_restrictions = [
     { paths = "lib/accounts-v2/lib/slipstream/contracts/**", version = "=0.7.6" },
@@ -32,7 +31,6 @@ remappings = [
     "solmate/=lib/accounts-v2/lib/solmate/",
 ]
 fs_permissions = [{ access = "read", path = "./out"}, { access = "write", path = "./script/out"}]
-unchecked_cheatcode_artifacts = true
 # Transient storage composability warning (known safe pattern in v4-core):
 # - 2394: transient storage cleared at end of call
 # Solmate deprecation warnings (used in deployed contracts via accounts-v2):
@@ -53,7 +51,14 @@ ignored_warnings_from = [
 [lint]
 exclude_lints = [
     "asm-keccak256",
+    "calls-loop",
+    "missing-events-access-control",
+    "missing-zero-check",
+    "reentrancy-events",
+    "require-revert-in-loop",
+    "uninitialized-local",
     "unsafe-cheatcode",
+    "unused-return",
     "unwrapped-modifier-logic",
 ]
 ignore = [

--- a/script/Script.s.sol
+++ b/script/Script.s.sol
@@ -137,6 +137,7 @@ contract Sign is Test {
             amountOut = amountOut * (1e6 - SLIPPAGE) / 1e6;
         }
 
+        // forge-lint: disable-next-item(unsafe-typecast)
         uint32 validTo = uint32(block.timestamp + 1 hours);
 
         uint256 accountOwner = vm.envUint("PRIVATE_KEY_ACCOUNT_OWNER");

--- a/src/cl-managers/RouterTrampoline.sol
+++ b/src/cl-managers/RouterTrampoline.sol
@@ -40,13 +40,16 @@ contract RouterTrampoline is ReentrancyGuard {
         ERC20(tokenIn).safeApproveWithRetry(router, amountIn);
 
         // Execute swap.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         (bool success, bytes memory result) = router.call(callData);
         require(success, string(result));
 
         // Transfer the tokens back to the caller.
         balanceIn = ERC20(tokenIn).balanceOf(address(this));
         balanceOut = ERC20(tokenOut).balanceOf(address(this));
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (balanceIn > 0) ERC20(tokenIn).safeTransfer(msg.sender, balanceIn);
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         if (balanceOut > 0) ERC20(tokenOut).safeTransfer(msg.sender, balanceOut);
     }
 }

--- a/src/cl-managers/base/Slipstream.sol
+++ b/src/cl-managers/base/Slipstream.sol
@@ -388,8 +388,10 @@ abstract contract Slipstream is AbstractBase {
 
         // forge-lint: disable-next-item(unsafe-typecast)
         if (amount0Delta > 0) {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token0).safeTransfer(msg.sender, uint256(amount0Delta));
         } else if (amount1Delta > 0) {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token1).safeTransfer(msg.sender, uint256(amount1Delta));
         }
     }

--- a/src/cl-managers/base/UniswapV3.sol
+++ b/src/cl-managers/base/UniswapV3.sol
@@ -305,8 +305,10 @@ abstract contract UniswapV3 is AbstractBase {
 
         // forge-lint: disable-next-item(unsafe-typecast)
         if (amount0Delta > 0) {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token0).safeTransfer(msg.sender, uint256(amount0Delta));
         } else if (amount1Delta > 0) {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token1).safeTransfer(msg.sender, uint256(amount1Delta));
         }
     }

--- a/src/cl-managers/base/UniswapV4.sol
+++ b/src/cl-managers/base/UniswapV4.sol
@@ -218,7 +218,9 @@ abstract contract UniswapV4 is AbstractBase {
 
         // Generate calldata to collect fees (decrease liquidity with liquidityDelta = 0).
         bytes memory actions = new bytes(2);
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[0] = bytes1(uint8(Actions.DECREASE_LIQUIDITY));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[1] = bytes1(uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(position.id, 0, 0, 0, "");
@@ -296,7 +298,9 @@ abstract contract UniswapV4 is AbstractBase {
 
         // Generate calldata to burn the position and collect the underlying assets.
         bytes memory actions = new bytes(2);
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[0] = bytes1(uint8(Actions.BURN_POSITION));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[1] = bytes1(uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(position.id, 0, 0, "");
@@ -333,7 +337,9 @@ abstract contract UniswapV4 is AbstractBase {
 
         // Generate calldata to burn the position and collect the underlying assets.
         bytes memory actions = new bytes(2);
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[0] = bytes1(uint8(Actions.DECREASE_LIQUIDITY));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[1] = bytes1(uint8(Actions.TAKE_PAIR));
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(position.id, liquidity, 0, 0, "");
@@ -423,10 +429,11 @@ abstract contract UniswapV4 is AbstractBase {
         if (delta.amount0() < 0) {
             POOL_MANAGER.sync(currency0);
             if (currency0.isAddressZero()) {
+                // forge-lint: disable-next-item(unsafe-typecast)
                 POOL_MANAGER.settle{ value: uint128(-delta.amount0()) }();
             } else {
                 // Transfer is properly handled by Currency library.
-                // forge-lint: disable-next-line(erc20-unchecked-transfer)
+                // forge-lint: disable-next-item(erc20-unchecked-transfer,unsafe-typecast)
                 currency0.transfer(address(POOL_MANAGER), uint128(-delta.amount0()));
                 POOL_MANAGER.settle();
             }
@@ -434,16 +441,18 @@ abstract contract UniswapV4 is AbstractBase {
         if (delta.amount1() < 0) {
             POOL_MANAGER.sync(currency1);
             // Transfer is properly handled by Currency library.
-            // forge-lint: disable-next-line(erc20-unchecked-transfer)
+            // forge-lint: disable-next-item(erc20-unchecked-transfer,unsafe-typecast)
             currency1.transfer(address(POOL_MANAGER), uint128(-delta.amount1()));
             POOL_MANAGER.settle();
         }
 
         // Withdraw tokens that the Pool Manager owes.
         if (delta.amount0() > 0) {
+            // forge-lint: disable-next-item(unsafe-typecast)
             POOL_MANAGER.take(currency0, (address(this)), uint128(delta.amount0()));
         }
         if (delta.amount1() > 0) {
+            // forge-lint: disable-next-item(unsafe-typecast)
             POOL_MANAGER.take(currency1, address(this), uint128(delta.amount1()));
         }
     }
@@ -478,6 +487,7 @@ abstract contract UniswapV4 is AbstractBase {
         position.id = POSITION_MANAGER.nextTokenId();
 
         // Calculate liquidity to be added.
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.liquidity = LiquidityAmounts.getLiquidityForAmounts(
             uint160(position.sqrtPrice),
             TickMath.getSqrtPriceAtTick(position.tickLower),
@@ -497,8 +507,11 @@ abstract contract UniswapV4 is AbstractBase {
 
         // Generate calldata to mint new position.
         bytes memory actions = new bytes(3);
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[0] = bytes1(uint8(Actions.MINT_POSITION));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[1] = bytes1(uint8(Actions.SETTLE_PAIR));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[2] = bytes1(uint8(Actions.SWEEP));
         bytes[] memory params = new bytes[](3);
         params[0] = abi.encode(
@@ -551,6 +564,7 @@ abstract contract UniswapV4 is AbstractBase {
         _checkAndApprovePermit2(position.tokens[1]);
 
         // Calculate liquidity to be added.
+        // forge-lint: disable-next-item(unsafe-typecast)
         position.liquidity = LiquidityAmounts.getLiquidityForAmounts(
             uint160(position.sqrtPrice),
             TickMath.getSqrtPriceAtTick(position.tickLower),
@@ -565,8 +579,11 @@ abstract contract UniswapV4 is AbstractBase {
 
         // Generate calldata to mint new position.
         bytes memory actions = new bytes(3);
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[0] = bytes1(uint8(Actions.INCREASE_LIQUIDITY));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[1] = bytes1(uint8(Actions.SETTLE_PAIR));
+        // forge-lint: disable-next-item(unsafe-typecast)
         actions[2] = bytes1(uint8(Actions.SWEEP));
         bytes[] memory params = new bytes[](3);
         params[0] = abi.encode(position.id, position.liquidity, type(uint128).max, type(uint128).max, "");
@@ -591,6 +608,8 @@ abstract contract UniswapV4 is AbstractBase {
      * @notice Ensures that the Permit2 contract has sufficient approval to spend a given token.
      * @param token The contract address of the token.
      */
+    // The approval flag is set before the external calls, so re-entry is a no-op.
+    // forge-lint: disable-next-item(reentrancy-no-eth)
     function _checkAndApprovePermit2(address token) internal {
         if (!approved[token]) {
             approved[token] = true;

--- a/src/cl-managers/compounders/Compounder.sol
+++ b/src/cl-managers/compounders/Compounder.sol
@@ -265,6 +265,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
         account = account_;
 
         // If the initiator is set, account_ is an actual Arcadia Account.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (accountToInitiator[IAccount(account_).owner()][account_] != msg.sender) revert InvalidInitiator();
         if (!isPositionManager(initiatorParams.positionManager)) revert InvalidPositionManager();
 
@@ -287,6 +288,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
         );
 
         // Call flashAction() with this contract as actionTarget.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account_).flashAction(address(this), actionData);
 
         // Reset account.
@@ -464,6 +466,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
         // This can be done either directly through the pool, or via a router with custom swap data.
         if (initiatorParams.swapData.length == 0) {
             // Calculate a more accurate amountOut, with slippage.
+            // forge-lint: disable-next-item(unsafe-typecast)
             uint256 amountOut = RebalanceOptimizationMath._getAmountOutWithSlippage(
                 rebalanceParams.zeroToOne,
                 position.fee,
@@ -507,6 +510,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
             zeroToOne ? (position.tokens[0], position.tokens[1]) : (position.tokens[1], position.tokens[0]);
 
         // Send tokens to the Router Trampoline.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(tokenIn).safeTransfer(address(ROUTER_TRAMPOLINE), amountIn);
 
         // Execute swap.
@@ -558,6 +562,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
             }
 
             // Transfer Initiator fees to the initiator.
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             if (fees[i] > 0) ERC20(token).safeTransfer(initiator, fees[i]);
             emit FeePaid(msg.sender, initiator, token, fees[i]);
         }
@@ -578,6 +583,7 @@ abstract contract Compounder is IActionBase, AbstractBase, Guardian {
             (bool success, bytes memory result) = payable(msg.sender).call{ value: address(this).balance }("");
             require(success, string(result));
         } else {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
         }
     }

--- a/src/cl-managers/compounders/CompounderUniswapV4.sol
+++ b/src/cl-managers/compounders/CompounderUniswapV4.sol
@@ -93,6 +93,7 @@ contract CompounderUniswapV4 is Compounder, UniswapV4 {
         }
 
         // Send tokens to the Router Trampoline.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(tokenIn).safeTransfer(address(ROUTER_TRAMPOLINE), amountIn);
 
         // Execute swap.

--- a/src/cl-managers/libraries/RebalanceOptimizationMath.sol
+++ b/src/cl-managers/libraries/RebalanceOptimizationMath.sol
@@ -143,6 +143,7 @@ library RebalanceOptimizationMath {
             // We could as well use the geometric average, but empirically we found no difference in conversion speed,
             // and the geometric average is more expensive to calculate.
             // Unchecked + unsafe cast: sqrtPriceNew0 and sqrtPriceNew1 are always smaller than type(uint160).max.
+            // forge-lint: disable-next-item(unsafe-typecast)
             sqrtPriceNew = zeroToOne
                 ? uint160(FixedPointMathLib.unsafeDiv(sqrtPriceNew0 + sqrtPriceNew1, 2))
                 : uint160(FixedPointMathLib.unsafeDivUp(sqrtPriceNew0 + sqrtPriceNew1, 2));

--- a/src/cl-managers/rebalancers/Rebalancer.sol
+++ b/src/cl-managers/rebalancers/Rebalancer.sol
@@ -310,6 +310,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
         account = account_;
 
         // If the initiator is set, account_ is an actual Arcadia Account.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (accountToInitiator[IAccount(account_).owner()][account_] != msg.sender) revert InvalidInitiator();
         if (!isPositionManager(initiatorParams.positionManager)) revert InvalidPositionManager();
 
@@ -332,6 +333,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
         );
 
         // Call flashAction() with this contract as actionTarget.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account_).flashAction(address(this), actionData);
 
         // Reset account.
@@ -538,6 +540,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
             // Calculate a more accurate amountOut, with slippage.
             uint256 amount0 = balances[0] - fees[0] - initiatorParams.amountOut0;
             uint256 amount1 = balances[1] - fees[1] - initiatorParams.amountOut1;
+            // forge-lint: disable-next-item(unsafe-typecast)
             uint256 amountOut = RebalanceOptimizationMath._getAmountOutWithSlippage(
                 rebalanceParams.zeroToOne,
                 position.fee,
@@ -581,6 +584,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
             zeroToOne ? (position.tokens[0], position.tokens[1]) : (position.tokens[1], position.tokens[0]);
 
         // Send tokens to the Router Trampoline.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(tokenIn).safeTransfer(address(ROUTER_TRAMPOLINE), amountIn);
 
         // Execute swap.
@@ -642,6 +646,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
             }
 
             // Transfer Initiator fees to the initiator.
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             if (fees[i] > 0) ERC20(token).safeTransfer(initiator, fees[i]);
             emit FeePaid(msg.sender, initiator, token, fees[i]);
         }
@@ -662,6 +667,7 @@ abstract contract Rebalancer is IActionBase, AbstractBase, Guardian {
             (bool success, bytes memory result) = payable(msg.sender).call{ value: address(this).balance }("");
             require(success, string(result));
         } else {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
         }
     }

--- a/src/cl-managers/rebalancers/RebalancerUniswapV4.sol
+++ b/src/cl-managers/rebalancers/RebalancerUniswapV4.sol
@@ -94,6 +94,7 @@ contract RebalancerUniswapV4 is Rebalancer, UniswapV4 {
         }
 
         // Send tokens to the Router Trampoline.
+        // forge-lint: disable-next-item(solmate-safe-transfer-lib)
         ERC20(tokenIn).safeTransfer(address(ROUTER_TRAMPOLINE), amountIn);
 
         // Execute swap.

--- a/src/cl-managers/yield-claimers/YieldClaimer.sol
+++ b/src/cl-managers/yield-claimers/YieldClaimer.sol
@@ -187,6 +187,7 @@ abstract contract YieldClaimer is IActionBase, AbstractBase, Guardian {
         account = account_;
 
         // If the initiator is set, account_ is an actual Arcadia Account.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (accountToInitiator[IAccount(account_).owner()][account_] != msg.sender) revert InvalidInitiator();
         if (!isPositionManager(initiatorParams.positionManager)) revert InvalidPositionManager();
 
@@ -202,6 +203,7 @@ abstract contract YieldClaimer is IActionBase, AbstractBase, Guardian {
         );
 
         // Call flashAction() with this contract as actionTarget.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account_).flashAction(address(this), actionData);
 
         // Reset account.
@@ -293,6 +295,7 @@ abstract contract YieldClaimer is IActionBase, AbstractBase, Guardian {
                     count++;
                 } else {
                     // Else, send the yield to the fee recipient.
+                    // forge-lint: disable-next-item(solmate-safe-transfer-lib)
                     ERC20(token).safeTransfer(recipient, amount);
                     balances[i] = 0;
                 }
@@ -303,6 +306,7 @@ abstract contract YieldClaimer is IActionBase, AbstractBase, Guardian {
             }
 
             // Transfer Initiator fees to the initiator.
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             if (fees[i] > 0) ERC20(token).safeTransfer(initiator, fees[i]);
             emit FeePaid(msg.sender, initiator, token, fees[i]);
 
@@ -325,6 +329,7 @@ abstract contract YieldClaimer is IActionBase, AbstractBase, Guardian {
             (bool success, bytes memory result) = payable(msg.sender).call{ value: address(this).balance }("");
             require(success, string(result));
         } else {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
         }
     }

--- a/src/cl-managers/yield-claimers/YieldClaimerSlipstream.sol
+++ b/src/cl-managers/yield-claimers/YieldClaimerSlipstream.sol
@@ -61,5 +61,6 @@ contract YieldClaimerSlipstream is YieldClaimer, Slipstream {
      * param positionManager The contract address of the Position Manager.
      * param position A struct with position and pool related variables.
      */
+    // forge-lint: disable-next-item(empty-block)
     function _stake(uint256[] memory, address, PositionState memory) internal override(AbstractBase, Slipstream) { }
 }

--- a/src/cow-swapper/CowSwapper.sol
+++ b/src/cow-swapper/CowSwapper.sol
@@ -297,6 +297,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
 
         // If the Initiator is non zero, we know account_ is an actual Arcadia Account,
         // and the initiator is set by its current owner.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         address accountOwner_ = IAccount(account_).owner();
         address initiator_ = ownerToAccountToInitiator[accountOwner_][account_];
         if (initiator_ == address(0)) revert InvalidInitiator();
@@ -311,6 +312,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
         bytes memory actionData = ArcadiaLogic._encodeAction(tokenIn_, amountIn_, callBackData);
 
         // Call flashAction() with this contract as actionTarget.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         IAccount(account_).flashAction(address(this), actionData);
 
         // Reset account.
@@ -323,6 +325,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
      * @param target The address to approve as spender (unused).
      * @param amount The amount to approve (unused).
      */
+    // forge-lint: disable-next-item(empty-block)
     function approve(address token, address target, uint256 amount) external { }
 
     /**
@@ -365,6 +368,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
         // Verify that "isValidSignature()" was called.
         // A malicious solver could modify the EIP-1271 signature, skipping the check that the orderHash is correct.
         // If isValidSignature() would be skipped, tokenIn would not be transferred from this contract to the vault relayer.
+        // forge-lint: disable-next-item(incorrect-strict-equality)
         if (IERC20(tokenIn_).balanceOf(address(this)) != balanceBefore_ - amountIn) {
             revert MissingSignatureVerification();
         }
@@ -415,6 +419,7 @@ contract CowSwapper is IActionBase, EIP712, Guardian {
         // The swap parameters may only be set before the swap, so the sell token must still be fully present.
         // Once it has been pulled the parameters are final and may not be changed. A re-supplied tokenIn balance
         // is detected by the "balanceBefore_ - amountIn" check in executeAction().
+        // forge-lint: disable-next-item(incorrect-strict-equality)
         if (IERC20(tokenIn).balanceOf(address(this)) != balanceBefore) revert SwapAlreadyExecuted();
 
         // Cache variables.

--- a/src/merkl-operator/MerklOperator.sol
+++ b/src/merkl-operator/MerklOperator.sol
@@ -136,9 +136,11 @@ contract MerklOperator is Guardian, ReentrancyGuard {
         bytes calldata metaData_
     ) external nonReentrant {
         if (!ARCADIA_FACTORY.isAccount(account)) revert NotAnAccount();
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         address accountOwner = IAccount(account).owner();
         if (msg.sender != accountOwner) revert OnlyAccountOwner();
         // Block Account versions without cross account reentrancy guard.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (IAccount(account).ACCOUNT_VERSION() < 3) revert InvalidAccountVersion();
 
         _setAccountInfo(account, accountOwner, initiator, rewardRecipient, maxClaimFee, metaData_);
@@ -184,6 +186,7 @@ contract MerklOperator is Guardian, ReentrancyGuard {
      */
     function claim(address account, InitiatorParams calldata initiatorParams) external whenNotPaused nonReentrant {
         // If the initiator is set, account is an actual Arcadia Account.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (accountToInitiator[IAccount(account).owner()][account] != msg.sender) revert InvalidInitiator();
 
         // Validate initiatorParams.
@@ -209,6 +212,7 @@ contract MerklOperator is Guardian, ReentrancyGuard {
         }
 
         // Claim Merkl rewards.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         MERKL_DISTRIBUTOR.claim(users, initiatorParams.tokens, initiatorParams.amounts, initiatorParams.proofs);
 
         // Transfer rewards to recipient and fees to initiator.
@@ -228,12 +232,14 @@ contract MerklOperator is Guardian, ReentrancyGuard {
 
             // Send the reward to the rewardRecipient.
             if (reward > 0) {
+                // forge-lint: disable-next-item(solmate-safe-transfer-lib)
                 ERC20(token).safeTransfer(rewardRecipient, reward);
                 emit YieldTransferred(account, rewardRecipient, token, reward);
             }
 
             // Transfer Initiator fees to the initiator.
             if (fee > 0) {
+                // forge-lint: disable-next-item(solmate-safe-transfer-lib)
                 ERC20(token).safeTransfer(msg.sender, fee);
                 emit FeePaid(account, msg.sender, token, fee);
             }
@@ -250,9 +256,11 @@ contract MerklOperator is Guardian, ReentrancyGuard {
      */
     function skim(address token) external onlyOwner whenNotPaused nonReentrant {
         if (token == address(0)) {
+            // forge-lint: disable-next-item(reentrancy-eth)
             (bool success, bytes memory result) = payable(msg.sender).call{ value: address(this).balance }("");
             require(success, string(result));
         } else {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
         }
     }

--- a/src/merkl-operator/MerklOperatorBase.sol
+++ b/src/merkl-operator/MerklOperatorBase.sol
@@ -106,9 +106,11 @@ contract MerklOperatorBase is Guardian, ReentrancyGuard {
      */
     function setAccountInfo(address account, address initiator, bytes calldata metaData_) external nonReentrant {
         if (!ARCADIA_FACTORY.isAccount(account)) revert NotAnAccount();
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         address accountOwner = IAccount(account).owner();
         if (msg.sender != accountOwner) revert OnlyAccountOwner();
         // Block Account versions without cross account reentrancy guard.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (IAccount(account).ACCOUNT_VERSION() < 3) revert InvalidAccountVersion();
 
         _setAccountInfo(account, accountOwner, initiator, metaData_);
@@ -141,6 +143,7 @@ contract MerklOperatorBase is Guardian, ReentrancyGuard {
      */
     function claim(address account, InitiatorParams calldata initiatorParams) external whenNotPaused nonReentrant {
         // If the initiator is set, account is an actual Arcadia Account.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         if (accountToInitiator[IAccount(account).owner()][account] != msg.sender) revert InvalidInitiator();
 
         uint256 length = initiatorParams.tokens.length;
@@ -152,6 +155,7 @@ contract MerklOperatorBase is Guardian, ReentrancyGuard {
 
         // Claim Merkl rewards.
         // Rewards are automatically transferred to the account with the current Merkl Distributor deployed on base.
+        // forge-lint: disable-next-item(reentrancy-no-eth)
         MERKL_DISTRIBUTOR.claim(users, initiatorParams.tokens, initiatorParams.amounts, initiatorParams.proofs);
     }
 
@@ -165,9 +169,11 @@ contract MerklOperatorBase is Guardian, ReentrancyGuard {
      */
     function skim(address token) external onlyOwner whenNotPaused nonReentrant {
         if (token == address(0)) {
+            // forge-lint: disable-next-item(reentrancy-eth)
             (bool success, bytes memory result) = payable(msg.sender).call{ value: address(this).balance }("");
             require(success, string(result));
         } else {
+            // forge-lint: disable-next-item(solmate-safe-transfer-lib)
             ERC20(token).safeTransfer(msg.sender, ERC20(token).balanceOf(address(this)));
         }
     }

--- a/test/CompilePragma8Dot26.t.sol
+++ b/test/CompilePragma8Dot26.t.sol
@@ -16,5 +16,6 @@ import { Test } from "../lib/accounts-v2/lib/forge-std/src/Test.sol";
 // forge-lint: disable-end(unused-import)
 
 contract CompilePragma8Dot26 is Test {
+    // forge-lint: disable-next-item(empty-block)
     function test() public { }
 }

--- a/test/fuzz/cl-managers/RouterTrampoline/Execute.fuzz.t.sol
+++ b/test/fuzz/cl-managers/RouterTrampoline/Execute.fuzz.t.sol
@@ -11,6 +11,7 @@ import { stdError } from "../../../../lib/accounts-v2/lib/forge-std/src/StdError
 /**
  * @notice Fuzz tests for the function "execute" of contract "RouterTrampoline".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Execute_RouterTrampoline_Fuzz_Test is RouterTrampoline_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/base/Slipstream/Burn.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Burn.fuzz.t.sol
@@ -56,6 +56,7 @@ contract Burn_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
         balances = base.burn(balances, positionManager, position);
 
         // Then: It should return the correct balances.
+        // forge-lint: disable-next-item(unsafe-typecast)
         (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
             uint160(position.sqrtPrice),
             TickMath.getSqrtPriceAtTick(position.tickLower),

--- a/test/fuzz/cl-managers/base/Slipstream/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Claim.fuzz.t.sol
@@ -19,6 +19,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_claim" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Claim_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/base/Slipstream/GetPositionState.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/GetPositionState.fuzz.t.sol
@@ -13,6 +13,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_getPositionState" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetPositionState_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/base/Slipstream/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/IncreaseLiquidity.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_increaseLiquidity" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/Slipstream/Mint.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Mint.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_mint" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/Slipstream/SwapViaPool.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/SwapViaPool.fuzz.t.sol
@@ -13,6 +13,7 @@ import {
 /**
  * @notice Fuzz tests for the function "_swapViaPool" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract SwapViaPool_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/Slipstream/Unstake.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/Unstake.fuzz.t.sol
@@ -18,6 +18,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_unstake" of contract "Slipstream".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Unstake_Slipstream_Fuzz_Test is Slipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/base/Slipstream/_Slipstream.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/Slipstream/_Slipstream.fuzz.t.sol
@@ -32,6 +32,7 @@ import {
 /**
  * @notice Common logic needed by all "Slipstream" fuzz tests.
  */
+// forge-lint: disable-next-item(divide-before-multiply,reentrancy-no-eth,unsafe-typecast)
 abstract contract Slipstream_Fuzz_Test is
     Fuzz_Test,
     SlipstreamFixture,

--- a/test/fuzz/cl-managers/base/UniswapV3/Burn.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/Burn.fuzz.t.sol
@@ -54,6 +54,7 @@ contract Burn_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
         balances = base.burn(balances, positionManager, position);
 
         // Then: It should return the correct balances.
+        // forge-lint: disable-next-item(unsafe-typecast)
         (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
             uint160(position.sqrtPrice),
             TickMath.getSqrtPriceAtTick(position.tickLower),

--- a/test/fuzz/cl-managers/base/UniswapV3/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/Claim.fuzz.t.sol
@@ -40,6 +40,7 @@ contract Claim_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
         setPositionState(position);
 
         // And: claimFee is below 100%.
+        // forge-lint: disable-next-item(unsafe-typecast)
         claimFee = uint64(bound(claimFee, 0, 1e18));
 
         // And: Base has balances.

--- a/test/fuzz/cl-managers/base/UniswapV3/GetPositionState.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/GetPositionState.fuzz.t.sol
@@ -38,6 +38,7 @@ contract GetPositionState_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
         assertEq(position_.id, position.id);
         assertEq(position_.fee, POOL_FEE);
         assertEq(position_.tickSpacing, poolUniswap.tickSpacing());
+        // forge-lint: disable-next-item(unsafe-typecast)
         assertEq(position_.tickCurrent, TickMath.getTickAtSqrtPrice(uint160(position.sqrtPrice)));
         assertEq(position_.tickLower, position.tickLower);
         assertEq(position_.tickUpper, position.tickUpper);

--- a/test/fuzz/cl-managers/base/UniswapV3/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/IncreaseLiquidity.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_increaseLiquidity" of contract "UniswapV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV3/Mint.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/Mint.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_mint" of contract "UniswapV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV3/SwapViaPool.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/SwapViaPool.fuzz.t.sol
@@ -13,6 +13,7 @@ import {
 /**
  * @notice Fuzz tests for the function "_swapViaPool" of contract "UniswapV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract SwapViaPool_UniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV3/_UniswapV3.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV3/_UniswapV3.fuzz.t.sol
@@ -35,6 +35,7 @@ import { Utils } from "../../../../../lib/accounts-v2/test/utils/Utils.sol";
 /**
  * @notice Common logic needed by all "UniswapV3" fuzz tests.
  */
+// forge-lint: disable-next-item(divide-before-multiply,encode-packed-collision,unsafe-typecast)
 abstract contract UniswapV3_Fuzz_Test is Fuzz_Test, UniswapV3Fixture, UniswapV3AMFixture, SwapRouter02Fixture {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS

--- a/test/fuzz/cl-managers/base/UniswapV4/Burn.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/Burn.fuzz.t.sol
@@ -13,6 +13,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_burn" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Burn_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/Claim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { UniswapV4_Fuzz_Test } from "./_UniswapV4.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_claim" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Claim_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -104,6 +105,7 @@ contract Claim_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
         balances[1] = balance1;
         vm.deal(address(base), balance0);
         vm.prank(address(base));
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: balance0 }();
         deal(address(token1), address(base), balance1, true);
 

--- a/test/fuzz/cl-managers/base/UniswapV4/GetPositionState.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/GetPositionState.fuzz.t.sol
@@ -11,6 +11,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_getPositionState" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetPositionState_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/GetUnderlyingTokens.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/GetUnderlyingTokens.fuzz.t.sol
@@ -11,6 +11,7 @@ import { UniswapV4_Fuzz_Test } from "./_UniswapV4.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_getUnderlyingTokens" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract GetUnderlyingTokens_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/IncreaseLiquidity.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/IncreaseLiquidity.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_increaseLiquidity" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract IncreaseLiquidity_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/Mint.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/Mint.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_mint" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Mint_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/SwapViaPool.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/SwapViaPool.fuzz.t.sol
@@ -13,6 +13,7 @@ import {
 /**
  * @notice Fuzz tests for the function "_swapViaPool" of contract "UniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract SwapViaPool_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/base/UniswapV4/Unstake.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/Unstake.fuzz.t.sol
@@ -76,6 +76,7 @@ contract Unstake_UniswapV4_Fuzz_Test is UniswapV4_Fuzz_Test {
         // And: Base has WETH balance.
         vm.deal(address(base), wethBalance);
         vm.prank(address(base));
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: wethBalance }();
 
         // And: Base has balances.

--- a/test/fuzz/cl-managers/base/UniswapV4/_UniswapV4.fuzz.t.sol
+++ b/test/fuzz/cl-managers/base/UniswapV4/_UniswapV4.fuzz.t.sol
@@ -31,6 +31,7 @@ import {
 /**
  * @notice Common logic needed by all "UniswapV4" fuzz tests.
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 abstract contract UniswapV4_Fuzz_Test is Fuzz_Test, UniswapV4Fixture {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS

--- a/test/fuzz/cl-managers/compounders/Compounder/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/Compounder/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/ExecuteAction.fuzz.t.sol
@@ -10,6 +10,7 @@ import { Compounder_Fuzz_Test } from "./_Compounder.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "Compounder".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ExecuteAction_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/compounders/Compounder/OnSetAssetManager.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/OnSetAssetManager.fuzz.t.sol
@@ -11,6 +11,7 @@ import { FixedPointMathLib } from "../../../../../lib/accounts-v2/lib/solmate/sr
 /**
  * @notice Fuzz tests for the function "onSetAssetManager" of contract "Compounder".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OnSetAssetManager_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/compounders/Compounder/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/SetAccountInfo.fuzz.t.sol
@@ -15,6 +15,7 @@ import { StdStorage, stdStorage } from "../../../../../lib/accounts-v2/lib/forge
 /**
  * @notice Fuzz tests for the function "setAccountInfo" of contract "Compounder".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAccountInfo_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/Compounder/SwapViaRouter.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/Compounder/SwapViaRouter.fuzz.t.sol
@@ -13,6 +13,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_swapViaRouter" of contract "Compounder".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SwapViaRouter_Compounder_Fuzz_Test is Compounder_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/compounders/CompounderSlipstream/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderSlipstream/Compound.fuzz.t.sol
@@ -22,6 +22,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "compound" of contract "CompounderSlipstream".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Rebalance_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/CompounderSlipstream/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderSlipstream/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/CompounderSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderSlipstream/ExecuteAction.fuzz.t.sol
@@ -24,7 +24,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "CompounderSlipstream".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_CompounderSlipstream_Fuzz_Test is CompounderSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /*////////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Compound.fuzz.t.sol
@@ -15,6 +15,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "compound" of contract "CompounderUniswapV3".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Compound_CompounderUniswapV3_Fuzz_Test is CompounderUniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -168,6 +169,7 @@ contract Compound_CompounderUniswapV3_Fuzz_Test is CompounderUniswapV3_Fuzz_Test
         liquidityPool = uint128(bound(liquidityPool, 1e25, 1e30));
         setPoolState(liquidityPool, position);
         position.tickLower = int24(bound(position.tickLower, BOUND_TICK_LOWER, position.tickCurrent - 1));
+        // forge-lint: disable-next-item(divide-before-multiply)
         position.tickLower = position.tickLower / position.tickSpacing * position.tickSpacing;
         position.tickUpper = int24(bound(position.tickUpper, position.tickCurrent, BOUND_TICK_UPPER));
         position.tickUpper = position.tickCurrent + (position.tickCurrent - position.tickLower);

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV3/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_CompounderUniswapV3_Fuzz_Test is CompounderUniswapV3_Fuzz_T
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV3/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV3/ExecuteAction.fuzz.t.sol
@@ -18,7 +18,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "CompounderUniswapV3".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_CompounderUniswapV3_Fuzz_Test is CompounderUniswapV3_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV3/_CompounderUniswapV3.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV3/_CompounderUniswapV3.fuzz.t.sol
@@ -47,6 +47,7 @@ abstract contract CompounderUniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
 
         // Overwrite code hash of the UniswapV3Pool.
         bytes memory args = abi.encode();
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("UniswapV3PoolExtension.sol"), args);
         bytes32 poolExtensionInitCodeHash = keccak256(bytecode);
         bytecode = address(compounder).code;

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Compound.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Compound.fuzz.t.sol
@@ -17,6 +17,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "compound" of contract "CompounderUniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Rebalance_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -324,6 +325,7 @@ contract Rebalance_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_Tes
         ERC721(address(positionManagerV4)).transferFrom(users.liquidityProvider, users.accountOwner, position.id);
         vm.deal(users.accountOwner, initiatorParams.amount0);
         vm.prank(users.accountOwner);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: initiatorParams.amount0 }();
         deal(address(token1), users.accountOwner, initiatorParams.amount1, true);
         {

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV4/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_T
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV4/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV4/ExecuteAction.fuzz.t.sol
@@ -19,7 +19,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "CompounderUniswapV4".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(arbitrary-send-eth,divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/compounders/CompounderUniswapV4/SwapViaRouter.fuzz.t.sol
+++ b/test/fuzz/cl-managers/compounders/CompounderUniswapV4/SwapViaRouter.fuzz.t.sol
@@ -14,6 +14,7 @@ import { stdError } from "../../../../../lib/accounts-v2/lib/forge-std/src/StdEr
 /**
  * @notice Fuzz tests for the function "_swapViaRouter" of contract "CompounderUniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SwapViaRouter_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS
@@ -222,6 +223,7 @@ contract SwapViaRouter_CompounderUniswapV4_Fuzz_Test is CompounderUniswapV4_Fuzz
         // And: Router mock has balanceOut.
         vm.deal(address(routerMock), amountOut);
         vm.prank(address(routerMock));
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: amountOut }();
 
         // When: Calling swapViaRouter.

--- a/test/fuzz/cl-managers/libraries/RebalanceLogic/GetRebalanceParams.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceLogic/GetRebalanceParams.fuzz.t.sol
@@ -14,6 +14,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_getRebalanceParams" of contract "RebalanceLogic".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetRebalanceParams_RebalanceLogic_Fuzz_Test is RebalanceLogic_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS
@@ -340,6 +341,7 @@ contract GetRebalanceParams_RebalanceLogic_Fuzz_Test is RebalanceLogic_Fuzz_Test
         {
             uint256 denominator = 1e18 - targetRatio * fee / 1e18;
             amountInWithFee = (currentRatio - targetRatio) * totalValueInToken1 / denominator;
+            // forge-lint: disable-next-item(divide-before-multiply)
             uint256 amountInitiatorFee_ = amountInWithFee * testVars.initiatorFee / 1e18;
             assertEq(rebalanceParams.amountInitiatorFee, amountInitiatorFee_);
         }

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/ApproximateOptimalSwapAmounts.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/ApproximateOptimalSwapAmounts.fuzz.t.sol
@@ -16,6 +16,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_approximateOptimalSwapAmounts" of contract "RebalanceOptimizationMath".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ApproximateOptimalSwapAmounts_SwapMath_Fuzz_Test is RebalanceOptimizationMath_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/ApproximateSqrtPriceNew.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/ApproximateSqrtPriceNew.fuzz.t.sol
@@ -12,6 +12,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_approximateSqrtPriceNew" of contract "RebalanceOptimizationMath".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ApproximateSqrtPriceNew_SwapMath_Fuzz_Test is RebalanceOptimizationMath_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmount0OutFromAmount1In.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmount0OutFromAmount1In.fuzz.t.sol
@@ -12,6 +12,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_getAmount0OutFromAmount1In" of contract "RebalanceOptimizationMath".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetAmount0OutFromAmount1In_SwapMath_Fuzz_Test is RebalanceOptimizationMath_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP
@@ -41,6 +42,7 @@ contract GetAmount0OutFromAmount1In_SwapMath_Fuzz_Test is RebalanceOptimizationM
 
         // And: amountOut without slippage would not overflow.
         if (sqrtPriceOld > FixedPoint96.Q96) {
+            // forge-lint: disable-next-item(divide-before-multiply)
             amount1 = uint128(
                 bound(amount1, 0, type(uint256).max / sqrtPriceOld * FixedPoint96.Q96 / sqrtPriceOld * FixedPoint96.Q96)
             );

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmount1OutFromAmount0In.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmount1OutFromAmount0In.fuzz.t.sol
@@ -34,9 +34,11 @@ contract GetAmount1OutFromAmount0In_SwapMath_Fuzz_Test is RebalanceOptimizationM
         fee = bound(fee, 0, 1e6);
 
         // And: sqrtPriceOld is within boundaries and smaller than type(uint128).max.
+        // forge-lint: disable-next-item(unsafe-typecast)
         sqrtPriceOld = uint160(bound(sqrtPriceOld, TickMath.MIN_SQRT_PRICE, TickMath.MIN_SQRT_PRICE));
 
         // And: amountOut without slippage would not overflow.
+        // forge-lint: disable-next-item(divide-before-multiply)
         amount0 =
             bound(amount0, 0, type(uint256).max / FixedPoint96.Q96 * sqrtPriceOld / FixedPoint96.Q96 * sqrtPriceOld);
 

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmountOutWithSlippage.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetAmountOutWithSlippage.fuzz.t.sol
@@ -25,6 +25,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_getAmountOutWithSlippage" of contract "RebalanceOptimizationMath".
  */
+// forge-lint: disable-next-item(divide-before-multiply)
 contract GetAmountOutWithSlippage_SwapMath_Fuzz_Test is
     RebalanceOptimizationMath_Fuzz_Test,
     UniswapV3Fixture,

--- a/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetSwapParamsExact.fuzz.t.sol
+++ b/test/fuzz/cl-managers/libraries/RebalanceOptimizationMath/GetSwapParamsExact.fuzz.t.sol
@@ -10,6 +10,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_getSwapParamsExact" of contract "RebalanceOptimizationMath".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetSwapParamsExact_SwapMath_Fuzz_Test is RebalanceOptimizationMath_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/ApproveAndTransfer.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/ApproveAndTransfer.fuzz.t.sol
@@ -15,6 +15,7 @@ import { UniswapV3Fixture } from "../../../../../lib/accounts-v2/test/utils/fixt
 /**
  * @notice Fuzz tests for the function "_approveAndTransfer" of contract "Rebalancer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ApproveAndTransfer_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/ExecuteAction.fuzz.t.sol
@@ -11,6 +11,7 @@ import { Rebalancer_Fuzz_Test } from "./_Rebalancer.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "Rebalancer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ExecuteAction_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               TEST CONTRACTS

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/OnSetAssetManager.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/OnSetAssetManager.fuzz.t.sol
@@ -12,6 +12,7 @@ import { Rebalancer_Fuzz_Test } from "./_Rebalancer.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "onSetAssetManager" of contract "Rebalancer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OnSetAssetManager_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               TEST CONTRACTS

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/Rebalance.fuzz.t.sol
@@ -156,6 +156,7 @@ contract Rebalance_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
         );
 
         // And: Fees are valid.
+        // forge-lint: disable-next-item(unsafe-typecast)
         initiatorParams.claimFee = uint64(bound(initiatorParams.claimFee, 0.001 * 1e18, MAX_FEE));
         initiatorParams.swapFee = initiatorParams.claimFee;
 

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/SetAccountInfo.fuzz.t.sol
@@ -16,6 +16,7 @@ import { StdStorage, stdStorage } from "../../../../../lib/accounts-v2/lib/forge
 /**
  * @notice Fuzz tests for the function "setAccountInfo" of contract "Rebalancer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAccountInfo_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/Rebalancer/SwapViaRouter.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/Rebalancer/SwapViaRouter.fuzz.t.sol
@@ -14,6 +14,7 @@ import { UniswapHelpers } from "../../../../utils/uniswap-v3/UniswapHelpers.sol"
 /**
  * @notice Fuzz tests for the function "_swapViaRouter" of contract "Rebalancer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SwapViaRouter_Rebalancer_Fuzz_Test is Rebalancer_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS

--- a/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/ExecuteAction.fuzz.t.sol
@@ -24,7 +24,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "RebalancerSlipstream".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /*////////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerSlipstream/Rebalance.fuzz.t.sol
@@ -21,6 +21,7 @@ import { StdStorage, stdStorage } from "../../../../../lib/accounts-v2/lib/forge
 /**
  * @notice Fuzz tests for the function "rebalance" of contract "RebalancerSlipstream".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Rebalance_RebalancerSlipstream_Fuzz_Test is RebalancerSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /*////////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_RebalancerUniswapV3_Fuzz_Test is RebalancerUniswapV3_Fuzz_T
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/ExecuteAction.fuzz.t.sol
@@ -18,7 +18,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "RebalancerUniswapV3".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_RebalancerUniswapV3_Fuzz_Test is RebalancerUniswapV3_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/Rebalance.fuzz.t.sol
@@ -14,6 +14,7 @@ import { RebalancerUniswapV3_Fuzz_Test } from "./_RebalancerUniswapV3.fuzz.t.sol
 /**
  * @notice Fuzz tests for the function "rebalance" of contract "RebalancerUniswapV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Rebalance_RebalancerUniswapV3_Fuzz_Test is RebalancerUniswapV3_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/_RebalancerUniswapV3.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV3/_RebalancerUniswapV3.fuzz.t.sol
@@ -47,6 +47,7 @@ abstract contract RebalancerUniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
 
         // Overwrite code hash of the UniswapV3Pool.
         bytes memory args = abi.encode();
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("UniswapV3PoolExtension.sol"), args);
         bytes32 poolExtensionInitCodeHash = keccak256(bytecode);
         bytecode = address(rebalancer).code;

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_T
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/ExecuteAction.fuzz.t.sol
@@ -20,7 +20,7 @@ import { TickMath } from "../../../../../lib/accounts-v2/lib/v4-periphery/lib/v4
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "RebalancerUniswapV4".
  */
-// forge-lint: disable-next-item(unsafe-typecast)
+// forge-lint: disable-next-item(arbitrary-send-eth,divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Rebalance.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/Rebalance.fuzz.t.sol
@@ -16,6 +16,7 @@ import { RebalancerUniswapV4_Fuzz_Test } from "./_RebalancerUniswapV4.fuzz.t.sol
 /**
  * @notice Fuzz tests for the function "rebalance" of contract "RebalancerUniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Rebalance_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             VARIABLES
@@ -378,6 +379,7 @@ contract Rebalance_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_Tes
         ERC721(address(positionManagerV4)).transferFrom(users.liquidityProvider, users.accountOwner, position.id);
         vm.deal(users.accountOwner, initiatorParams.amountIn0);
         vm.prank(users.accountOwner);
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: initiatorParams.amountIn0 }();
         deal(address(token1), users.accountOwner, initiatorParams.amountIn1, true);
         {

--- a/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/SwapViaRouter.fuzz.t.sol
+++ b/test/fuzz/cl-managers/rebalancers/RebalancerUniswapV4/SwapViaRouter.fuzz.t.sol
@@ -14,6 +14,7 @@ import { stdError } from "../../../../../lib/accounts-v2/lib/forge-std/src/StdEr
 /**
  * @notice Fuzz tests for the function "_swapViaRouter" of contract "RebalancerUniswapV4".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SwapViaRouter_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz_Test {
     /*////////////////////////////////////////////////////////////////
                             CONSTANTS
@@ -214,6 +215,7 @@ contract SwapViaRouter_RebalancerUniswapV4_Fuzz_Test is RebalancerUniswapV4_Fuzz
         // And: Router mock has balanceOut.
         vm.deal(address(routerMock), amountOut);
         vm.prank(address(routerMock));
+        // forge-lint: disable-next-item(arbitrary-send-eth)
         IWETH(address(weth9)).deposit{ value: amountOut }();
 
         // When: Calling swapViaRouter.

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/ExecuteAction.fuzz.t.sol
@@ -10,6 +10,7 @@ import { YieldClaimer_Fuzz_Test } from "./_YieldClaimer.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "YieldClaimer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ExecuteAction_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/OnSetAssetManager.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/OnSetAssetManager.fuzz.t.sol
@@ -10,6 +10,7 @@ import { YieldClaimer_Fuzz_Test } from "./_YieldClaimer.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "onSetAssetManager" of contract "YieldClaimer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OnSetAssetManager_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimer/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimer/SetAccountInfo.fuzz.t.sol
@@ -14,6 +14,7 @@ import { StdStorage, stdStorage } from "../../../../../lib/accounts-v2/lib/forge
 /**
  * @notice Fuzz tests for the function "setAccountInfo" of contract "YieldClaimer".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAccountInfo_YieldClaimer_Fuzz_Test is YieldClaimer_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Claim.fuzz.t.sol
@@ -21,6 +21,7 @@ import { YieldClaimerSlipstream_Fuzz_Test } from "./_YieldClaimerSlipstream.fuzz
 /**
  * @notice Fuzz tests for the function "claim" of contract "YieldClaimerSlipstream".
  */
+// forge-lint: disable-next-item(divide-before-multiply,reentrancy-no-eth,unsafe-typecast)
 contract Compound_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerSlipstream/ExecuteAction.fuzz.t.sol
@@ -19,6 +19,7 @@ import { YieldClaimerSlipstream_Fuzz_Test } from "./_YieldClaimerSlipstream.fuzz
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "YieldClaimerSlipstream".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_YieldClaimerSlipstream_Fuzz_Test is YieldClaimerSlipstream_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Claim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { PositionState } from "../../../../../src/cl-managers/state/PositionStat
 /**
  * @notice Fuzz tests for the function "claim" of contract "YieldClaimerUniswapV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Compound_YieldClaimerUniswapV3_Fuzz_Test is YieldClaimerUniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_YieldClaimerUniswapV3_Fuzz_Test is YieldClaimerUniswapV3_Fu
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/ExecuteAction.fuzz.t.sol
@@ -13,6 +13,7 @@ import { PositionState } from "../../../../../src/cl-managers/state/PositionStat
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "YieldClaimerUniswapV3".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_YieldClaimerUniswapV3_Fuzz_Test is YieldClaimerUniswapV3_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/_YieldClaimerUniswapV3.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV3/_YieldClaimerUniswapV3.fuzz.t.sol
@@ -33,6 +33,7 @@ abstract contract YieldClaimerUniswapV3_Fuzz_Test is UniswapV3_Fuzz_Test {
 
         // Overwrite code hash of the UniswapV3Pool.
         bytes memory args = abi.encode();
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode = abi.encodePacked(vm.getCode("UniswapV3PoolExtension.sol"), args);
         bytes32 poolExtensionInitCodeHash = keccak256(bytecode);
 

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Claim.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Claim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { PositionState } from "../../../../../src/cl-managers/state/PositionStat
 /**
  * @notice Fuzz tests for the function "claim" of contract "YieldClaimerUniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract Compound_YieldClaimerUniswapV4_Fuzz_Test is YieldClaimerUniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Constructor.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_YieldClaimerUniswapV4_Fuzz_Test is YieldClaimerUniswapV4_Fu
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cl-managers/yield-claimers/YieldClaimerUniswapV4/ExecuteAction.fuzz.t.sol
@@ -14,6 +14,7 @@ import { YieldClaimerUniswapV4_Fuzz_Test } from "./_YieldClaimerUniswapV4.fuzz.t
 /**
  * @notice Fuzz tests for the function "_executeAction" of contract "YieldClaimerUniswapV4".
  */
+// forge-lint: disable-next-item(divide-before-multiply,unsafe-typecast)
 contract ExecuteAction_YieldClaimerUniswapV4_Fuzz_Test is YieldClaimerUniswapV4_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cow-swapper/CowSwapper/ApproveTokens.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/ApproveTokens.fuzz.t.sol
@@ -11,6 +11,7 @@ import { ERC20Mock } from "../../../../lib/accounts-v2/test/utils/mocks/tokens/E
 /**
  * @notice Fuzz tests for the function "approveTokens" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ApproveTokens_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cow-swapper/CowSwapper/BeforeSwap.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/BeforeSwap.fuzz.t.sol
@@ -11,6 +11,7 @@ import { GPv2Order } from "../../../../lib/cowprotocol/src/contracts/libraries/G
 /**
  * @notice Fuzz tests for the function "beforeSwap" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract BeforeSwap_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     using GPv2Order for GPv2Order.Data;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/EndToEnd.fuzz.t.sol
@@ -19,6 +19,7 @@ import { MaliciousSolver } from "../../../utils/mocks/MaliciousSolver.sol";
 /**
  * @notice Fuzz tests for the function full "flashLoanAndSettle" flow of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract EndToEnd_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cow-swapper/CowSwapper/ExecuteAction.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/ExecuteAction.fuzz.t.sol
@@ -17,6 +17,7 @@ import { MaliciousSolver } from "../../../utils/mocks/MaliciousSolver.sol";
 /**
  * @notice Fuzz tests for the function "executeAction" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract ExecuteAction_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     using LibString for string;
     using LoansWithSettlement for bytes;

--- a/test/fuzz/cow-swapper/CowSwapper/FlashLoanAndCallBack.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/FlashLoanAndCallBack.fuzz.t.sol
@@ -153,6 +153,7 @@ contract FlashLoanAndCallBack_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
         address initiator = vm.addr(initiatorPrivateKey);
 
         // And: Valid swap fee.
+        // forge-lint: disable-next-item(unsafe-typecast)
         swapFee = uint64(bound(swapFee, 0, MAX_FEE));
 
         // And: Valid order.

--- a/test/fuzz/cow-swapper/CowSwapper/GetMessageHash.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/GetMessageHash.fuzz.t.sol
@@ -10,6 +10,7 @@ import { GPv2Order } from "../../../../lib/cowprotocol/src/contracts/libraries/G
 /**
  * @notice Fuzz tests for the function "getMessageHash" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetMessageHash_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     using GPv2Order for GPv2Order.Data;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cow-swapper/CowSwapper/OnSetMerklOperator.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/OnSetMerklOperator.fuzz.t.sol
@@ -10,6 +10,7 @@ import { CowSwapper_Fuzz_Test } from "./_CowSwapper.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "onSetAssetManager" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OnSetCowSwapper_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/cow-swapper/CowSwapper/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/SetAccountInfo.fuzz.t.sol
@@ -14,6 +14,7 @@ import { StdStorage, stdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Fuzz tests for the function "setAccountInfo" of contract "CowSwapper".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAccountInfo_CowSwapper_Fuzz_Test is CowSwapper_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/cow-swapper/CowSwapper/_CowSwapper.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/CowSwapper/_CowSwapper.fuzz.t.sol
@@ -22,6 +22,7 @@ import { WETH9Fixture } from "../../../../lib/accounts-v2/test/utils/fixtures/we
 /**
  * @notice Common logic needed by all "CowSwapper" fuzz tests.
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 abstract contract CowSwapper_Fuzz_Test is Fuzz_Test, BalancerV2Fixture, CowSwapFixture, WETH9Fixture {
     using GPv2Order for GPv2Order.Data;
     using LoansWithSettlement for bytes;

--- a/test/fuzz/cow-swapper/DefaultOrderHook/GetInitiatorParams.fuzz.t.sol
+++ b/test/fuzz/cow-swapper/DefaultOrderHook/GetInitiatorParams.fuzz.t.sol
@@ -10,6 +10,7 @@ import { GPv2Order } from "../../../../lib/cowprotocol/src/contracts/libraries/G
 /**
  * @notice Fuzz tests for the function "getInitiatorParams" of contract "DefaultOrderHook".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract GetInitiatorParams_DefaultOrderHook_Fuzz_Test is DefaultOrderHook_Fuzz_Test {
     using GPv2Order for GPv2Order.Data;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/merkl-operator/MerklOperator/Claim.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/Claim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { MerklOperator_Fuzz_Test } from "./_MerklOperator.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "claim" of contract "MerklOperator".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Claim_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/merkl-operator/MerklOperator/Constructor.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/fuzz/merkl-operator/MerklOperator/OnSetMerklOperator.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/OnSetMerklOperator.fuzz.t.sol
@@ -10,6 +10,7 @@ import { MerklOperator_Fuzz_Test } from "./_MerklOperator.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "onSetMerklOperator" of contract "MerklOperator".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract OnSetMerklOperator_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/merkl-operator/MerklOperator/SetAccountInfo.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperator/SetAccountInfo.fuzz.t.sol
@@ -14,6 +14,7 @@ import { StdStorage, stdStorage } from "../../../../lib/accounts-v2/lib/forge-st
 /**
  * @notice Fuzz tests for the function "setAccountInfo" of contract "MerklOperator".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract SetAccountInfo_MerklOperator_Fuzz_Test is MerklOperator_Fuzz_Test {
     using stdStorage for StdStorage;
     /* ///////////////////////////////////////////////////////////////

--- a/test/fuzz/merkl-operator/MerklOperatorBase/Claim.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperatorBase/Claim.fuzz.t.sol
@@ -13,6 +13,7 @@ import { MerklOperatorBase_Fuzz_Test } from "./_MerklOperatorBase.fuzz.t.sol";
 /**
  * @notice Fuzz tests for the function "claim" of contract "MerklOperatorBase".
  */
+// forge-lint: disable-next-item(unsafe-typecast)
 contract Claim_MerklOperatorBase_Fuzz_Test is MerklOperatorBase_Fuzz_Test {
     /* ///////////////////////////////////////////////////////////////
                               SETUP

--- a/test/fuzz/merkl-operator/MerklOperatorBase/Constructor.fuzz.t.sol
+++ b/test/fuzz/merkl-operator/MerklOperatorBase/Constructor.fuzz.t.sol
@@ -15,6 +15,7 @@ contract Constructor_MerklOperatorBase_Fuzz_Test is MerklOperatorBase_Fuzz_Test 
                               SETUP
     /////////////////////////////////////////////////////////////// */
 
+    // forge-lint: disable-next-item(empty-block)
     function setUp() public override { }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/utils/extensions/CompounderExtension.sol
+++ b/test/utils/extensions/CompounderExtension.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { Compounder } from "../../../src/cl-managers/compounders/Compounder.sol";
 import { PositionState } from "../../../src/cl-managers/state/PositionState.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract CompounderExtension is Compounder {
     constructor(address owner_, address arcadiaFactory, address routerTrampoline)
         Compounder(owner_, arcadiaFactory, routerTrampoline)

--- a/test/utils/extensions/RebalancerExtension.sol
+++ b/test/utils/extensions/RebalancerExtension.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { PositionState } from "../../../src/cl-managers/state/PositionState.sol";
 import { Rebalancer } from "../../../src/cl-managers/rebalancers/Rebalancer.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract RebalancerExtension is Rebalancer {
     constructor(address owner_, address arcadiaFactory, address routerTrampoline)
         Rebalancer(owner_, arcadiaFactory, routerTrampoline)

--- a/test/utils/extensions/YieldClaimerExtension.sol
+++ b/test/utils/extensions/YieldClaimerExtension.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { PositionState } from "../../../src/cl-managers/state/PositionState.sol";
 import { YieldClaimer } from "../../../src/cl-managers/yield-claimers/YieldClaimer.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract YieldClaimerExtension is YieldClaimer {
     constructor(address owner_, address arcadiaFactory) YieldClaimer(owner_, arcadiaFactory) { }
 

--- a/test/utils/fixtures/balancer-v2/BalancerV2Fixture.f.sol
+++ b/test/utils/fixtures/balancer-v2/BalancerV2Fixture.f.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 
 import { Test } from "../../../../lib/accounts-v2/lib/forge-std/src/Test.sol";
 
+// forge-lint: disable-next-item(encode-packed-collision)
 contract BalancerV2Fixture is Test {
     /*//////////////////////////////////////////////////////////////////////////
                                    CONTRACTS

--- a/test/utils/fixtures/cow-swap/CowSwapFixture.f.sol
+++ b/test/utils/fixtures/cow-swap/CowSwapFixture.f.sol
@@ -59,6 +59,7 @@ contract CowSwapFixture is Test {
             abi.encode(manager),
             hex"00000000000000000000000000000000000000000000000000000000"
         );
+        // forge-lint: disable-next-item(encode-packed-collision)
         bytes memory bytecode =
             abi.encodePacked(CREATION_CODE_PROXY, abi.encode(address(implementation_), manager), data);
         (bool success, bytes memory value) = address(CREATE2).call{ value: 0 }(bytecode);

--- a/test/utils/mocks/DefaultRebalancerHook.sol
+++ b/test/utils/mocks/DefaultRebalancerHook.sol
@@ -9,6 +9,7 @@ import { PositionState } from "../../../src/cl-managers/state/PositionState.sol"
 import { StrategyHook } from "../../../src/cl-managers/rebalancers/periphery/StrategyHook.sol";
 import { TickMath } from "../../../lib/accounts-v2/lib/v4-periphery/lib/v4-core/src/libraries/TickMath.sol";
 
+// forge-lint: disable-next-item(divide-before-multiply)
 contract DefaultRebalancerHook is StrategyHook {
     using FixedPointMathLib for uint256;
     /* //////////////////////////////////////////////////////////////
@@ -149,5 +150,6 @@ contract DefaultRebalancerHook is StrategyHook {
      * param newPosition The state of the new position.
      * param strategyData Encoded data containing strategy parameters.
      */
+    // forge-lint: disable-next-item(empty-block)
     function afterRebalance(address, address, uint256, PositionState memory, bytes memory) external override { }
 }

--- a/test/utils/mocks/HooksTrampoline.sol
+++ b/test/utils/mocks/HooksTrampoline.sol
@@ -68,6 +68,7 @@ contract HooksTrampoline {
                     revertByWastingGas();
                 }
 
+                // forge-lint: disable-next-item(return-bomb)
                 (bool success,) = hook.target.call{ gas: hook.gasLimit }(hook.callData);
 
                 // In order to prevent custom hooks from DoS-ing settlements, we

--- a/test/utils/mocks/RebalancerHookMock.sol
+++ b/test/utils/mocks/RebalancerHookMock.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import { PositionState } from "../../../src/cl-managers/state/PositionState.sol";
 import { StrategyHook } from "../../../src/cl-managers/rebalancers/periphery/StrategyHook.sol";
 
+// forge-lint: disable-next-item(empty-block)
 contract RebalancerHookMock is StrategyHook {
     function setStrategy(address account, bytes calldata strategyData) external override { }
     function beforeRebalance(


### PR DESCRIPTION
Mark the forge 1.8 lint findings that are intentional with inline directives, per site in src and at contract level in the tests. Rules that fire across the whole codebase go in exclude_lints instead.

Needs forge 1.8.1, directives on findings reported in an inherited file were ignored before that.

Also drops dynamic_test_linking = false and unchecked_cheatcode_artifacts = true. Both were only needed because the artifact lookup broke when the artifact list is disabled, see foundry-rs/foundry#16468.
