### PR TITLE
👷 Only check out the submodules that are compiled

### DIFF
--- a/.github/workflows/foundryFuzz.yml
+++ b/.github/workflows/foundryFuzz.yml
@@ -10,9 +10,13 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v5
+
+      - name: Check out the submodules that are compiled
+        run: |
+          git submodule update --init
+          git -C lib/accounts-v2 submodule update --init
+          git -C lib/accounts-v2 submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,13 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
+      - uses: actions/checkout@v5
+
+      - name: Check out the submodules that are compiled
+        run: |
+          git submodule update --init
+          git -C lib/accounts-v2 submodule update --init
+          git -C lib/accounts-v2 submodule update --init --recursive lib/slipstream lib/v4-periphery
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/foundry.toml
+++ b/foundry.toml
@@ -44,8 +44,7 @@ unchecked_cheatcode_artifacts = true
 # - 5574: Contract code size exceeds 24576 bytes
 ignored_error_codes = [2394, 2424, 3860, 4591, 5574, 8429]
 ignored_warnings_from = [
-    "lib/accounts-v2/lib/slipstream/contracts/gauge/interfaces/ICLPool.sol",
-    "lib/accounts-v2/lib/slipstream/contracts/libraries/EnumerableSet.sol",
+    "lib/accounts-v2/lib/",
     "lib/cowprotocol/",
     "lib/flash-loan-router/",
 ]


### PR DESCRIPTION
CI cloned the whole recursive submodule tree. Check out only the submodules that are compiled, matching accounts-v2#354.

- `git submodule update --init` at the top level
- recurse only into `lib/slipstream` and `lib/v4-periphery` under accounts-v2
- `actions/checkout@v5`

Applies to both `test.yml` and `foundryFuzz.yml`.

Also carries `1fb7edb`, which drops the redundant foundry.toml entry so dependency warnings stay ignored.